### PR TITLE
improve ssl security

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -183,6 +183,8 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
             self.socket = ssl.wrap_socket(self.socket,
                                           keyfile=self.key_file,
                                           certfile=self.certificate,
+                                          ssl_version=3,
+                                          ciphers="ALL:!COMPLEMENTOFDEFAULT:!eNULL:!aNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!DH:!RC4;",
                                           server_side=True)
 
     def handle_error(self, request, client_address):


### PR DESCRIPTION
Selects TLS version 1.0 as the channel encryption protocol with Python2.7.
Configure ssl ciphers list without RC4 to improve ssl security.